### PR TITLE
MetaData Serialisation and Search Indices for MetaData and Cas

### DIFF
--- a/src/dakoda/corpus.py
+++ b/src/dakoda/corpus.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import random
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
-from collections.abc import Iterable
+from typing import Iterator, Literal
 
 import polars as pl
 from cassis import Cas
@@ -46,16 +48,6 @@ class DakodaDocument:
 
 
 class DakodaCorpus:
-    # this method can remain as a convenience method.
-    @staticmethod
-    def document_meta(doc: DakodaDocument) -> MetaData:
-        """Return the metadata of the given document."""
-        return doc.meta
-
-    @staticmethod
-    def document_meta_df(doc: DakodaDocument) -> pl.DataFrame:
-        return doc.meta.to_df()
-
     ts = load_dakoda_typesystem()
 
     def __init__(self, path):
@@ -63,8 +55,6 @@ class DakodaCorpus:
         self.name = self.path.stem
         self.document_paths = list(self.path.glob("*.xmi"))
         self.document_paths.sort()
-        self._meta_cache = CorpusMetaCache(self)
-        self._meta_cache.corpus = self
 
     def __repr__(self):
         return f"DakodaCorpus(name={self.name}, path={self.path})"
@@ -130,69 +120,114 @@ class DakodaCorpus:
         xmi = random.choice(self.document_paths)
         return self._get_by_path(xmi)
 
-    def generate_corpus_meta_df(self, use_cached=True) -> pl.DataFrame:
-        """Return a DataFrame with metadata for the whole corpus."""
 
-        if use_cached and self._meta_cache.is_empty():
-            try:
-                return self._meta_cache.read()
-            except Exception:
-                pass  # fallback to uncached path
-
-        data = [doc.meta.to_df(i) for i, doc in enumerate(self.docs)]
-
-        df_all = pl.concat(data,  how="vertical").with_columns(
-            pl.col(["field", "_module_name", "_class_name"]).cast(pl.Categorical)
-        )
-
-        # fixme: self._meta_cache.write(df_all) needs serialisation and deserialisation
-        return df_all
+@dataclass
+class FieldMapping:
+    name: str
+    dtype: any
+    mapping_fn: Callable | None = None
 
 
-# TODO: cache_dir constant, configurable via .env / config.py?
-class CorpusMetaCache:
-    def __init__(self, corpus: DakodaCorpus, cache_dir: str | Path = ".meta_cache", fmt='.parquet'):
-        self.corpus = corpus
-        self.cache_dir = Path(cache_dir)
-        self.format = fmt
+class Indexer(ABC):
+    default_field_mappings = {
+        'idx': FieldMapping('idx', pl.Int64),
+        'view': FieldMapping('view', pl.Categorical),
+        'type': FieldMapping('type', pl.Categorical),
+        'field': FieldMapping('field', pl.Categorical),
+        'value': FieldMapping('value', pl.Object)
+    }
+
+    def __init__(self, field_mappings: dict[str, FieldMapping] | None = None):
+        if field_mappings is None:
+            field_mappings = self.default_field_mappings.copy()
+        self.field_mappings = field_mappings
 
     @property
-    def cache_file(self):
-        return (self.cache_dir / self.corpus.name).with_suffix(self.format)
+    def schema(self):
+        return {field_mapping.name: field_mapping.dtype for field_mapping in self.field_mappings.values()}
 
-    def is_empty(self) -> bool:
-        return self.cache_file.exists()
+    @property
+    def column_mapping(self):
+        return {name: mapping.name for name, mapping in self.field_mappings.items()}
 
-    def write(self, df: pl.DataFrame) -> bool:
-        cache_dir = self.cache_dir
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        if self.format == '.csv':
-            df.write_csv(self.cache_file)
-        elif self.format == '.parquet':
-            df.write_parquet(self.cache_file)
-        else:
-            return False
-        return True
+    @abstractmethod
+    def to_entries(self, doc: DakodaDocument, idx = None):
+        pass
 
-    def read(self) -> pl.DataFrame:
-        return pl.read_csv(self.cache_file)
+    def index_corpus(self, corpus):
+        entries = []
+        for i, doc in enumerate(corpus.docs):
+            entries.extend(self.to_entries(doc, i))
+        return pl.DataFrame(entries, self.schema)
 
-    def clear(self):
-        self.cache_file.unlink(missing_ok=True)
+    def index_document(self, doc: DakodaDocument):
+        entries = self.to_entries(doc)
+        return pl.DataFrame(entries, self.schema)
 
-# this is an index, not a cache. probably the same for meta possible?
-class CorpusDocumentIndexCache:
-    def __init__(self, corpus: DakodaCorpus, cache_dir: str | Path | None = None):
+
+class CasIndexer(Indexer):
+    default_field_mappings = {
+        'idx': FieldMapping('idx', pl.Int64),
+        'view': FieldMapping('view', pl.Categorical),
+        'type': FieldMapping('type', pl.Categorical),
+        'field': FieldMapping('field', pl.Categorical),
+        'value': FieldMapping('value', pl.Utf8)
+    }
+
+    def to_entries(self, doc: DakodaDocument, idx = None):
+        entries = []
+        cas = doc.cas
+        for view_name, cas_view_name in view_to_name.items():
+            view = cas.get_view(cas_view_name)
+            for type_name, value_name in type_to_fieldname.items():
+                annotations = view.select(type_name)
+                for annotation in annotations:
+                    if value_name == 'coveredText':
+                        value = annotation.get_covered_text()
+                    else:
+                        value = annotation[value_name]
+                    entry = {
+                        self.column_mapping.get('idx'): idx,
+                        self.column_mapping.get('view'): view_name,
+                        self.column_mapping.get('type'): type_name.split('.')[-1],
+                        self.column_mapping.get('field'): value_name,
+                        self.column_mapping.get('value'): value
+                    }
+                    entries.append(entry)
+        return entries
+
+
+class MetaDataIndexer(Indexer):
+    default_field_mappings = {
+        'idx': FieldMapping('idx', pl.Int64),
+        'field': FieldMapping('field', pl.Categorical),
+        'value': FieldMapping('value', pl.Object)
+    }
+
+    def to_entries(self, doc: DakodaDocument, idx = None):
+        entries = []
+        for key, value in doc.meta.iter_flat():
+            entries.append({
+                self.column_mapping.get('idx'): idx,
+                self.column_mapping.get('field'): key,
+                self.column_mapping.get('value'): value,
+            })
+        return entries
+
+
+# TODO: generalize
+class IndexCache:
+    def __init__(self, corpus: DakodaCorpus, cache_name: Literal['cas', 'meta'], cache_dir: str | Path | None = None):
         self.corpus = corpus
+        self.cache_name = cache_name
         if cache_dir is None:
-            cache_dir = self.corpus.path / ".meta_cache" # todo align cache dirs
-
+            cache_dir = self.corpus.path / ".cache"
         self.cache_dir = Path(cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     @property
     def cache_file(self):
-        return (self.cache_dir / 'cas_cache').with_suffix(".parquet")
+        return (self.cache_dir / self.cache_name).with_suffix(".parquet")
 
     def write(self, df: pl.DataFrame) -> bool:
         df.write_parquet(self.cache_file)
@@ -200,35 +235,3 @@ class CorpusDocumentIndexCache:
 
     def read(self) -> pl.DataFrame:
         return pl.read_parquet(self.cache_file)
-
-
-def document_to_index_entries(doc: DakodaDocument, idx=None):
-    entries = []
-    cas = doc.cas
-    for view_name, cas_view_name in view_to_name.items():
-        view = cas.get_view(cas_view_name)
-        for type_name, value_name in type_to_fieldname.items():
-            annotations = view.select(type_name)
-            for annotation in annotations:
-                if value_name == 'coveredText':
-                    value = annotation.get_covered_text()
-                else:
-                    value = annotation[value_name]
-                entry = {
-                    'idx': idx,
-                    'view': view_name,
-                    'type': type_name.split('.')[-1],
-                    'field': value_name,
-                    'value': value
-                }
-                entries.append(entry)
-    return entries
-
-
-def document_index(corpus: DakodaCorpus) -> pl.DataFrame:
-    entries = []
-    for i, doc in enumerate(corpus):
-        entries.extend(document_to_index_entries(doc, i))
-    return pl.DataFrame(entries).with_columns(
-        pl.col(["view", "type", "field"]).cast(pl.Categorical)
-    )

--- a/src/dakoda/metadata/constants.py
+++ b/src/dakoda/metadata/constants.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
 import csv
+import json
+from decimal import Decimal
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 from importlib_resources import files
 from importlib_resources.abc import Traversable
+from xsdata.models.datatype import XmlPeriod
+
+class CustomJSONEncoder(json.JSONEncoder):
+    """JSON Encoder that handles all dataclasses."""
+
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, Enum):
+            return obj.value
+        elif isinstance(obj, Decimal):
+            return float(obj)
+        elif isinstance(obj, XmlPeriod):
+            return str(obj)
+        return super().default(obj)
 
 
 def _enum_from_file(file_path: str | Path | Traversable, separator=","):

--- a/src/dakoda/metadata/scheme.py
+++ b/src/dakoda/metadata/scheme.py
@@ -2308,7 +2308,7 @@ class MetaData(DocumentType):
         return asdict(self)
 
     def to_df(self):
-        meta_dict = self.to_dict()
+        meta_dict = dict(self.__iter__())
         return pl.DataFrame(meta_dict)
 
     def to_json(self):

--- a/src/dakoda/metadata/scheme.py
+++ b/src/dakoda/metadata/scheme.py
@@ -4,6 +4,7 @@ import io
 import json
 from dataclasses import dataclass, field, fields, is_dataclass, asdict
 from decimal import Decimal
+from enum import Enum
 from typing import List, Optional, Union, Any, Tuple, Iterator
 
 import polars as pl
@@ -2226,7 +2227,7 @@ class DocumentType:
 
 
 # Todo: Might be better as a class. seems to work fine for now.
-def _traverse_dataclass_fields(obj: Any, depth: int = 0) -> Iterator[Tuple[str, Any]]:
+def _traverse_dataclass_fields(obj: Any) -> Iterator[Tuple[str, Any]]:
     """
     Recursively traverse a dataclass object and yield all field names and values.
 
@@ -2260,20 +2261,26 @@ def _traverse_dataclass_fields(obj: Any, depth: int = 0) -> Iterator[Tuple[str, 
         if field_value is None:
             continue
         elif is_dataclass(field_value):
-            yield from _traverse_dataclass_fields(field_value, depth + 2)
+            yield from _traverse_dataclass_fields(field_value)
         elif isinstance(field_value, (list, tuple)):
             for i, item in enumerate(field_value):
                 if is_dataclass(item):
-                    yield from _traverse_dataclass_fields(item, depth + 3)
+                    yield from _traverse_dataclass_fields(item)
                 else:
-                    yield (f'{field.name}___{i}', item)
+                    if isinstance(item, Enum):
+                        item = item.value
+                    yield (field.name, item)
         elif isinstance(field_value, dict):
             for key, value in field_value.items():
                 if is_dataclass(value):
-                    yield from _traverse_dataclass_fields(value, depth + 3)
+                    yield from _traverse_dataclass_fields(value)
                 else:
+                    if isinstance(value, Enum):
+                        value = value.value
                     yield (key, value)
         else:
+            if isinstance(field_value, Enum):
+                field_value = field_value.value
             yield (field.name, field_value)
 
 
@@ -2301,15 +2308,30 @@ class MetaData(DocumentType):
     class Meta:
         name = "document"
 
-    def __iter__(self) -> Iterator[Tuple[str, Any]]:
+    def iter_flat(self) -> Iterator[Tuple[str, Any]]:
         return _traverse_dataclass_fields(self)
 
     def to_dict(self):
         return asdict(self)
 
-    def to_df(self):
-        meta_dict = dict(self.__iter__())
-        return pl.DataFrame(meta_dict)
+    def to_records(self, idx: int | None=None):
+        entries = []
+        for key, value in self.iter_flat():
+            entries.append({
+                'idx': idx,
+                'field': key,
+                'value': value,
+            })
+        return entries
+
+    def to_df(self, idx: int | None=None):
+        entries = self.to_records(idx=idx)
+        schema = {
+            "idx": pl.Int64,
+            "field": pl.Utf8,
+            "value": pl.Object,
+        }
+        return pl.DataFrame(entries, schema=schema)
 
     def to_json(self):
         return json.dumps(asdict(self), cls=CustomJSONEncoder)

--- a/src/dakoda/uima.py
+++ b/src/dakoda/uima.py
@@ -1,4 +1,5 @@
 import cassis
+from cassis import Cas
 from importlib_resources import files
 
 
@@ -10,6 +11,12 @@ def load_dakoda_typesystem():
 def load_cas_from_file(path, ts):
     with open(path, "rb") as f:
         return cassis.load_cas_from_xmi(f, typesystem=ts)
+
+
+def get_cas_meta_json_string(cas: Cas):
+    for meta in cas.select(T_META):
+        if meta.get("key") == "structured_metadata":
+            return meta.get("value")
 
 
 T_TOKEN = "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token"

--- a/src/dakoda/uima.py
+++ b/src/dakoda/uima.py
@@ -26,3 +26,17 @@ T_SENT = "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence"
 T_MORPH = "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.Morpheme"
 T_DEP = "de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency"
 T_META = "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.MetaDataStringField"
+T_STAGE = "org.dakoda.Stage"
+
+type_to_fieldname = {
+    T_TOKEN: 'coveredText',
+    T_LEMMA: 'lemma',
+    T_POS: 'posValue',
+    T_SENT: 'coveredText',
+    T_STAGE: 'name'
+}
+
+view_to_name = {
+    'learner': 'ctok',
+    'target_hypothesis': 'mixtral_th1'
+}

--- a/src/dakoda/uima.py
+++ b/src/dakoda/uima.py
@@ -30,8 +30,8 @@ T_STAGE = "org.dakoda.Stage"
 
 type_to_fieldname = {
     T_TOKEN: 'coveredText',
-    T_LEMMA: 'lemma',
-    T_POS: 'posValue',
+    T_LEMMA: 'value',
+    T_POS: 'PosValue',
     T_SENT: 'coveredText',
     T_STAGE: 'name'
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,10 @@ def wtld():
 
 
 @pytest.fixture
-def test_corpus(wtld):
-    return wtld
+def test_corpus():
+    corpus = DakodaCorpus(TESTFILES_DIR / "WTLD")
+    corpus.document_paths = corpus.document_paths[:10]
+    return corpus
 
 
 @pytest.fixture

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -3,7 +3,7 @@ import random
 
 import pytest
 
-from dakoda.corpus import DakodaDocument
+from dakoda.corpus import DakodaDocument, CasIndexer, MetaDataIndexer
 
 
 def test_load_corpus(wtld):
@@ -85,12 +85,21 @@ def test_document(test_cas, comigs):
     assert len(doc.text) != 0
 
 
-def test_document_meta_df(comigs):
-    doc = comigs[-1]
-    df = comigs.document_meta_df(doc)
-    assert not df.is_empty()
+def test_cas_indexer(test_corpus):
+    indexer = CasIndexer()
+
+    doc = test_corpus.random_doc()
+    doc_df = indexer.index_document(doc)
+    df = indexer.index_corpus(test_corpus)
+
+    assert df.columns == doc_df.columns
+    assert all(col in indexer.field_mappings.keys() for col in df.columns)
 
 
-def test_corpus_meta_df(comigs):
-    df = comigs.generate_corpus_meta_df()
-    assert not df.is_empty()
+def test_meta_indexer(test_corpus):
+    indexer = MetaDataIndexer()
+    doc = test_corpus.random_doc()
+    doc_df = indexer.index_document(doc)
+    df = indexer.index_corpus(test_corpus)
+    assert df.columns == doc_df.columns
+    assert all(col in indexer.field_mappings.keys() for col in df.columns)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,6 @@
 from dakoda.metadata import MetaData
-
+import tempfile
+from pathlib import Path
 
 def test_meta(test_cas):
     meta = MetaData.from_cas(test_cas)
@@ -12,3 +13,22 @@ def test_meta(test_cas):
 def test_document_meta(test_corpus):
     doc = test_corpus[0]
     meta = test_corpus.document_meta(doc)
+
+def test_serialization_deserialization_with_tmpfile(test_corpus):
+    """Test that MetaData can be serialized to JSON and deserialized back correctly"""
+    doc = test_corpus[0]
+    meta = test_corpus.document_meta(doc)
+
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.json', delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+
+        try:
+            tmp_file.write(meta.to_json())
+            tmp_file.flush()  # Ensure data is written
+
+            deserialized_meta = MetaData.from_json_file(tmp_path)
+
+            assert meta == deserialized_meta
+
+        finally:
+            tmp_path.unlink(missing_ok=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,14 +10,10 @@ def test_meta(test_cas):
     )  # FIXME: This should probably not be correct?
 
 
-def test_document_meta(test_corpus):
-    doc = test_corpus[0]
-    meta = test_corpus.document_meta(doc)
-
 def test_serialization_deserialization_with_tmpfile(test_corpus):
     """Test that MetaData can be serialized to JSON and deserialized back correctly"""
     doc = test_corpus[0]
-    meta = test_corpus.document_meta(doc)
+    meta = doc.meta
 
     with tempfile.NamedTemporaryFile(mode='w+', suffix='.json', delete=False) as tmp_file:
         tmp_path = Path(tmp_file.name)


### PR DESCRIPTION
This PR aims to bring performance improvements in preparation for the search API. It adds two main features:

- Lazy loading of Cas data.
- Serialisation and deserialisation for `MetaData` Objects. Th
- Unified Indexing for Documents (both `CAS` and `MetaData` objects).

## Lazy loading of Cas data
CAS data for `DakodaDocuments` is only loaded when needed, speeding up iteration through the corpus.

## Serialisation and Deserialisation
`MetaData` objects now have a `to_json` method that produces a valid JSON String representing the Object. When read with the `from_json_string` or `from_json_file` methods, the `MetaData` object is reconstructed.
This allows storing a document's metadata outside the CAS XMI, speeding up object construction.

## Unified Indexing for Documents
`DakodaDocument` objects have two primary data sources: The `MetaData` and the annotations, stored in a `Cas` file. For the query API, a prebuilt search index for both will be used to ensure fast lookup.
The index is built by the `Indexer` class (`MetaDataIndexer` and `CasIndexer` respectively). It converts the `MetaData` and `Cas` objects of the entire corpus into a single [narrow](https://en.wikipedia.org/wiki/Wide_and_narrow_data) Polars Dataframe each. The dataframe will be used to query values of interest and retrieve relevant document ids. 

### Format
Each row in the Dataframe represents a relevant value from a document in the corpus.
The Dataframes have the following columns:

- `idx: int`: The document index of the value.
- `view: categorical`: The view to which the value belongs. Only available for CasIndex.
- `type: categorical`: The UIMA Type from which the value was extracted. Only available for CasIndex.
- `field: categorical`: The name of the value.
- `value: object`: The value itself.

The categorical columns allow to easily and quickly filter and group relevant values, whereas the value field is used to check specific constraints on the values.