### PR TITLE
Document Access

### DIFF
--- a/src/dakoda/corpus.py
+++ b/src/dakoda/corpus.py
@@ -6,6 +6,8 @@ from collections.abc import Iterable, Callable
 from pathlib import Path
 from typing import Iterator, Literal, List
 
+import difflib
+
 import polars as pl
 from cassis import Cas
 
@@ -60,11 +62,19 @@ class DakodaDocument:
 
     @property
     def learner(self):
-        return self.view('ctok')
+        return self.view(view_to_name['learner'])
 
     @property
     def target_hypothesis(self):
-        return self.view('mixtral_th1')
+        return self.view(view_to_name['target_hypothesis'])
+
+
+    def text_diff(self, view_1: str = 'learner', view_2: str = 'target_hypothesis'):
+        view_1 = view_to_name.get(view_1, view_1)
+        view_2 = view_to_name.get(view_2, view_2)
+        tokens_1 = [token.text for token in self.view(view_1).tokens]
+        tokens_2 = [token.text for token in self.view(view_2).tokens]
+        return ''.join(difflib.context_diff(tokens_1, tokens_2))
 
 
 class DakodaCorpus:

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -107,6 +107,10 @@ def test_document(test_cas, comigs):
     ]
     assert all(len(anno) != 0 for anno in annos)
 
+    assert len(doc.text_diff()) > 0
+
+    assert doc.text_diff('ctok', 'ctok') != doc.text_diff()
+
 def test_cas_indexer(test_corpus):
     indexer = CasIndexer()
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -84,6 +84,28 @@ def test_document(test_cas, comigs):
     )
     assert len(doc.text) != 0
 
+    assert doc.learner.sentences[0].span == (0, 69)
+    assert len(doc.learner.sentences[0].text) == 69
+
+    pos = doc.learner.pos_tags[0]
+    pos_th = doc.target_hypothesis.pos_tags[0]
+
+    assert pos.span == (0, 4) and pos.value == 'ART'
+    assert pos_th.span == (0, 4) and pos_th.value == 'ART'
+    assert pos_th == pos
+
+    assert doc.learner.text != doc.target_hypothesis.text
+    assert not all(pos == pos_th for pos, pos_th in zip(doc.learner.pos_tags, doc.target_hypothesis.pos_tags))
+
+    learner = doc.learner
+    annos = [
+        learner.pos_tags,
+        learner.tokens,
+        learner.sentences,
+        learner.lemmas,
+        learner.stages
+    ]
+    assert all(len(anno) != 0 for anno in annos)
 
 def test_cas_indexer(test_corpus):
     indexer = CasIndexer()


### PR DESCRIPTION
This PR adds accessors to relevant document data without having to be familiar with UIMA or cassis.

`dakoda.corpus.DakodaDocument` was extended by the following attributes:
- `.learner`: `DocumentView` for the learner's text.
- `.target_hypothesis`: `DocumentView` for the automatically generated target hypothesis.
- `.view(type_name: str)`: `DocumentView` for the given View in the CAS.
- `.diff(view_1: str = 'learner', view_2: str = 'target_hypothesis')`: Difference between texts in the two views. Compares learner to target hypothesis by default.

The `dakoda.uima.DocumentView` is a wrapper for a CAS View and provides access to the following attributes:
- Relevant annotations are available as a list each (`.pos_tags`, `.tokens`, `.lemmas`, `.sentences`, `.stages`. Each is a list of `dakoda.uima.TypeAnnotation`s.
- Raw annotations can be accessed by providing their name to `._raw_annotation`

### Usage
```python
from dakoda import Dakoda

corpus = Dakoda('data/ComiGs')
doc = corpus.random_doc()

diff = doc.text_diff()
print(diff)

for pos in doc.learner.pos_tags:
    print(pos.text, pos.span, pos.value)
```